### PR TITLE
Add CLI helper for testing quote tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,103 @@
-# Quote-tool
+# Quote Tool
+
+A drop-in JavaScript quoting helper that reads a carrier underwriting data file and returns formatted life insurance quotes. The widget is designed so you can embed it on any site and customise the call-to-action that appears next to each quote.
+
+## Project structure
+
+```
+.
+├── carrier_underwriting.json   # Rate tables and product metadata
+├── quote_tool.js               # UMD module that calculates and renders quotes
+└── UNDERWRITING_REFERENCE.md   # Documentation for the JSON structure
+```
+
+## Getting started
+
+1. Update `carrier_underwriting.json` with your carrier rates.
+2. Load `quote_tool.js` on your site and initialise the calculator.
+3. Pass a request describing your client to `calculateQuotes`.
+4. Render the results next to your CTA button using `renderQuoteList`.
+
+### Browser example
+
+```html
+<div id="quote-output"></div>
+<script src="/path/to/quote_tool.js"></script>
+<script>
+  (async function () {
+    const data = await QuoteTool.loadUnderwritingData('/path/to/carrier_underwriting.json');
+    const calculator = new QuoteTool.QuoteCalculator(data);
+    const quotes = calculator.calculateQuotes({
+      age: 37,
+      gender: 'male',
+      state: 'TX',
+      coverageAmount: 500000,
+      termYears: 20,
+      productType: 'term',
+      healthClass: 'preferred plus',
+      nicotineUse: false,
+      modality: 'monthly',
+      buttonText: 'Book now',
+      linkUrl: 'https://youragency.com/appointments'
+    });
+
+    const container = document.getElementById('quote-output');
+    QuoteTool.renderQuoteList(quotes, { container });
+  }());
+</script>
+```
+
+### Node usage
+
+```js
+const { QuoteCalculator, loadUnderwritingData } = require('./quote_tool.js');
+
+(async () => {
+  const data = await loadUnderwritingData('./carrier_underwriting.json');
+  const calculator = new QuoteCalculator(data);
+  const quotes = calculator.calculateQuotes({
+    age: 45,
+    gender: 'female',
+    state: 'CA',
+    coverageAmount: 300000,
+    productType: 'term',
+    termYears: 20,
+    healthClass: 'preferred',
+    nicotineUse: false,
+    modality: 'monthly',
+    buttonText: 'Apply now',
+    linkUrl: 'https://example.com/apply'
+  });
+
+console.log(quotes.map((quote) => `${quote.carrier} - ${quote.premium}/${quote.modality}`));
+})();
+```
+
+### Quick CLI test
+
+For a fast sanity check without writing your own script, run the bundled helper:
+
+```bash
+node scripts/run_quote.js --age 40 --gender female --state CA --coverage 300000 --term 20 --health "preferred" --button "Book now" --link "https://example.com/book"
+```
+
+Omit any flags to fall back to the defaults shown in the usage output. The script prints each matching quote in the format `Carrier (Product) - Premium/modality - Button text`, followed by the CTA link so you can confirm everything is wired correctly before embedding the widget.
+
+### Customising the call-to-action
+
+When you call `calculateQuotes`, include `buttonText` and `linkUrl` properties. These values are copied to each quote so the rendered node can use any destination and label you choose.
+
+### Quote breakdowns
+
+Every quote returned from `calculateQuotes` includes a `breakdown` object with:
+
+* the base age band that was matched,
+* the multipliers that were applied (health, nicotine, state, product), and
+* the annual and modal premiums both before and after fees.
+
+Use this to debug results or display additional information to the end user.
+
+## License
+
+MIT
+

--- a/README.md
+++ b/README.md
@@ -18,6 +18,24 @@ A drop-in JavaScript quoting helper that reads a carrier underwriting data file 
 3. Pass a request describing your client to `calculateQuotes`.
 4. Render the results next to your CTA button using `renderQuoteList`.
 
+### Visual demo
+
+For a ready-to-run UI, open `index.html` from this repository with a local static server:
+
+```bash
+# from the repository root
+npx serve .
+# ...or...
+python -m http.server 8000
+```
+
+Then browse to the reported URL (for Python the default is http://localhost:8000/index.html). The demo mirrors the single-screen layout shown in the mock-up, automatically loads `carrier_underwriting.json`, and lets you:
+
+* adjust coverage, age, state, and gender;
+* toggle nicotine use and health conditions (the widget maps these to a reasonable health class automatically); and
+* customise the CTA label/link per quote.
+
+Click **Get Quotes** to render the results list. Every row includes the carrier, product, formatted modal premium, and your configured button.
 ### Browser example
 
 ```html

--- a/UNDERWRITING_REFERENCE.md
+++ b/UNDERWRITING_REFERENCE.md
@@ -1,0 +1,92 @@
+# Underwriting Data Reference
+
+This document explains how the `carrier_underwriting.json` file is structured so you can safely adjust rates, add carriers, and understand how the quote tool interprets each field.
+
+## Top-level keys
+
+| Key | Description |
+| --- | ----------- |
+| `metadata` | Optional information about the dataset. We currently use it to set the default currency (`currency`), the symbol to use when rendering prices (`currency_symbol`), and the coverage unit used when applying rate table values (`base_coverage_unit`). |
+| `carriers` | An array of carrier objects. Each carrier should contain a human-readable `name` and an array of `products`. |
+
+## Carrier object
+
+| Key | Required | Description |
+| --- | -------- | ----------- |
+| `name` | ✅ | Display name of the carrier. |
+| `products` | ✅ | Array of product definitions for the carrier. Each product is evaluated individually when we calculate quotes. |
+
+## Product object
+
+| Key | Required | Description |
+| --- | -------- | ----------- |
+| `name` | ✅ | Display name of the product (e.g. `Term 20`). |
+| `type` | ✅ | Product category. This value is normalised to lower-case (`term`, `whole`, `ul`, etc.) and can be used as a filter when requesting quotes. |
+| `term_years` | ❌ | Numeric term length. Use `null` for permanent products. When a user requests a specific term length we only consider products with a matching value. |
+| `base_coverage_unit` | ❌ | Overrides the dataset-level `base_coverage_unit` (defaults to 1,000). Rates are assumed to be *per unit*. |
+| `product_factor` | ❌ | Additional multiplier applied to the rate before fees. Use it to account for product-level loadings (defaults to `1`). |
+| `policy_fee_annual` | ❌ | Flat annual policy fee added before modality factors are applied (defaults to `0`). |
+| `modal_factors` | ❌ | Mapping of payment modal to a factor used to convert the annual premium into the requested frequency. If omitted we fall back to sensible defaults (`annual`, `semi_annual`, `quarterly`, `monthly`). |
+| `rate_table` | ✅ | Array of age bands (see below). |
+| `health_factors` | ❌ | Map of health classes to multipliers. Keys are lower-case with underscores (e.g. `preferred_plus`). Unrecognised classes default to `1`. |
+| `nicotine_factors` | ❌ | Map of nicotine use (`"true"` or `"false"`) to multipliers. Defaults to `1` for `false` and `1.5` for `true`. |
+| `state_factors` | ❌ | Map of state abbreviations to multipliers. |
+| `state_exclusions` | ❌ | Array of state abbreviations. If the applicant state is listed, the product is removed from consideration. |
+
+### Age band structure
+
+Each entry in `rate_table` defines the rate per coverage unit for a specific age range.
+
+```json
+{
+  "min_age": 31,
+  "max_age": 40,
+  "rates": {
+    "male": 0.225,
+    "female": 0.215
+  }
+}
+```
+
+* `min_age` and `max_age` are inclusive.
+* `rates` must contain keys for each supported gender (`male`, `female`).
+
+## Adding a new carrier
+
+1. Duplicate one of the existing carrier objects in `carrier_underwriting.json`.
+2. Update the `name` and adjust the product list.
+3. For each product make sure the age bands cover the entire target range of applicants.
+4. Provide health, nicotine, and state adjustments if the carrier differentiates in those areas.
+
+## Updating rates or factors
+
+* **Rates** – update the numeric values inside each `rates` object.
+* **Policy fee** – update `policy_fee_annual`.
+* **Modality factors** – adjust the values in `modal_factors`. The quote tool multiplies the annual premium (after adding the policy fee) by the chosen factor.
+
+## Validation tips
+
+* Ensure there are no overlapping or missing age bands for the same product.
+* Keep rates positive. Negative or zero values will result in the product being skipped.
+* If a state must be excluded, add it to `state_exclusions`. To surcharge or discount a state leave it out of exclusions and specify a multiplier in `state_factors` (e.g. `"CA": 1.07`).
+
+## Example request payload
+
+```js
+const request = {
+  age: 35,
+  gender: "female",
+  state: "CA",
+  coverageAmount: 250000,
+  termYears: 20,
+  productType: "term",
+  healthClass: "preferred plus",
+  nicotineUse: false,
+  modality: "monthly",
+  buttonText: "Book now",
+  linkUrl: "https://youragency.com/quote/123"
+};
+```
+
+Pass this object to `QuoteCalculator#calculateQuotes()` to receive an array of ranked quotes. Each quote includes a `breakdown` object that exposes the exact multipliers that were applied so you can audit the result.
+

--- a/carrier_underwriting.json
+++ b/carrier_underwriting.json
@@ -1,0 +1,234 @@
+{
+  "metadata": {
+    "currency": "USD",
+    "currency_symbol": "$",
+    "base_coverage_unit": 1000
+  },
+  "carriers": [
+    {
+      "name": "Americo",
+      "products": [
+        {
+          "name": "Term 20",
+          "type": "term",
+          "term_years": 20,
+          "base_coverage_unit": 1000,
+          "product_factor": 1,
+          "policy_fee_annual": 60,
+          "modal_factors": {
+            "annual": 1,
+            "semi_annual": 0.52,
+            "quarterly": 0.27,
+            "monthly": 0.09
+          },
+          "rate_table": [
+            {
+              "min_age": 18,
+              "max_age": 30,
+              "rates": { "male": 0.185, "female": 0.175 }
+            },
+            {
+              "min_age": 31,
+              "max_age": 40,
+              "rates": { "male": 0.225, "female": 0.215 }
+            },
+            {
+              "min_age": 41,
+              "max_age": 50,
+              "rates": { "male": 0.345, "female": 0.325 }
+            }
+          ],
+          "health_factors": {
+            "preferred_plus": 0.85,
+            "preferred": 0.9,
+            "standard_plus": 1,
+            "standard": 1.12
+          },
+          "nicotine_factors": {
+            "true": 1.6,
+            "false": 1
+          },
+          "state_factors": {
+            "CA": 1.05,
+            "FL": 1.08
+          }
+        },
+        {
+          "name": "Whole Life",
+          "type": "whole",
+          "term_years": null,
+          "base_coverage_unit": 1000,
+          "product_factor": 1.12,
+          "policy_fee_annual": 45,
+          "modal_factors": {
+            "annual": 1,
+            "semi_annual": 0.52,
+            "quarterly": 0.27,
+            "monthly": 0.089
+          },
+          "rate_table": [
+            {
+              "min_age": 18,
+              "max_age": 30,
+              "rates": { "male": 0.295, "female": 0.275 }
+            },
+            {
+              "min_age": 31,
+              "max_age": 45,
+              "rates": { "male": 0.365, "female": 0.335 }
+            },
+            {
+              "min_age": 46,
+              "max_age": 55,
+              "rates": { "male": 0.495, "female": 0.455 }
+            }
+          ],
+          "health_factors": {
+            "preferred_plus": 0.9,
+            "preferred": 0.95,
+            "standard_plus": 1,
+            "standard": 1.15
+          },
+          "nicotine_factors": {
+            "true": 1.5,
+            "false": 1
+          }
+        }
+      ]
+    },
+    {
+      "name": "Banner Life",
+      "products": [
+        {
+          "name": "OPTerm 30",
+          "type": "term",
+          "term_years": 30,
+          "product_factor": 0.98,
+          "policy_fee_annual": 70,
+          "rate_table": [
+            {
+              "min_age": 18,
+              "max_age": 30,
+              "rates": { "male": 0.165, "female": 0.155 }
+            },
+            {
+              "min_age": 31,
+              "max_age": 40,
+              "rates": { "male": 0.215, "female": 0.205 }
+            },
+            {
+              "min_age": 41,
+              "max_age": 50,
+              "rates": { "male": 0.315, "female": 0.295 }
+            }
+          ],
+          "health_factors": {
+            "preferred_plus": 0.82,
+            "preferred": 0.9,
+            "standard_plus": 1,
+            "standard": 1.08
+          },
+          "nicotine_factors": {
+            "true": 1.65,
+            "false": 1
+          },
+          "state_exclusions": ["NY"],
+          "state_factors": {
+            "TX": 0.97,
+            "WA": 1.04
+          }
+        },
+        {
+          "name": "Guaranteed UL",
+          "type": "ul",
+          "term_years": null,
+          "product_factor": 1.05,
+          "policy_fee_annual": 85,
+          "rate_table": [
+            {
+              "min_age": 25,
+              "max_age": 40,
+              "rates": { "male": 0.255, "female": 0.245 }
+            },
+            {
+              "min_age": 41,
+              "max_age": 55,
+              "rates": { "male": 0.345, "female": 0.325 }
+            },
+            {
+              "min_age": 56,
+              "max_age": 65,
+              "rates": { "male": 0.465, "female": 0.435 }
+            }
+          ],
+          "health_factors": {
+            "preferred_plus": 0.88,
+            "preferred": 0.94,
+            "standard_plus": 1,
+            "standard": 1.1,
+            "table_a": 1.2,
+            "table_b": 1.3
+          },
+          "nicotine_factors": {
+            "true": 1.7,
+            "false": 1
+          },
+          "state_factors": {
+            "NY": 1.12,
+            "MA": 1.08
+          }
+        }
+      ]
+    },
+    {
+      "name": "Protective",
+      "products": [
+        {
+          "name": "Custom Choice UL",
+          "type": "ul",
+          "term_years": 25,
+          "product_factor": 1,
+          "policy_fee_annual": 55,
+          "modal_factors": {
+            "annual": 1,
+            "semi_annual": 0.51,
+            "quarterly": 0.265,
+            "monthly": 0.088
+          },
+          "rate_table": [
+            {
+              "min_age": 18,
+              "max_age": 35,
+              "rates": { "male": 0.205, "female": 0.19 }
+            },
+            {
+              "min_age": 36,
+              "max_age": 45,
+              "rates": { "male": 0.275, "female": 0.255 }
+            },
+            {
+              "min_age": 46,
+              "max_age": 55,
+              "rates": { "male": 0.365, "female": 0.335 }
+            }
+          ],
+          "health_factors": {
+            "preferred_plus": 0.83,
+            "preferred": 0.9,
+            "standard_plus": 1,
+            "standard": 1.07,
+            "table_a": 1.18
+          },
+          "nicotine_factors": {
+            "true": 1.55,
+            "false": 1
+          },
+          "state_factors": {
+            "CA": 1.03,
+            "IL": 0.98
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,639 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Life Insurance Quote Tool Demo</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+        background-color: #f4f6fb;
+        line-height: 1.5;
+      }
+
+      body {
+        margin: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top, #eef1f8, #f4f6fb 45%);
+        color: #111827;
+      }
+
+      .page {
+        max-width: 960px;
+        margin: 0 auto;
+        padding: 48px 24px 64px;
+      }
+
+      .card {
+        background: #ffffff;
+        border-radius: 18px;
+        box-shadow: 0 20px 45px -35px rgba(15, 23, 42, 0.6);
+        padding: 36px;
+        margin-bottom: 32px;
+      }
+
+      h1 {
+        margin: 0;
+        font-size: clamp(1.8rem, 2vw + 1rem, 2.4rem);
+        font-weight: 700;
+        letter-spacing: -0.01em;
+      }
+
+      h2 {
+        font-size: 1.25rem;
+        margin: 0 0 12px;
+      }
+
+      p.lead {
+        margin: 8px 0 32px;
+        color: #4b5563;
+        max-width: 540px;
+      }
+
+      form {
+        display: grid;
+        gap: 20px;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+      }
+
+      .field label {
+        font-weight: 600;
+        margin-bottom: 6px;
+        color: #1f2937;
+      }
+
+      .field select,
+      .field input[type="number"],
+      .field input[type="text"],
+      .field input[type="url"],
+      .field input[type="range"] {
+        font: inherit;
+        padding: 12px 14px;
+        border-radius: 12px;
+        border: 1px solid #d1d5db;
+        background: #f9fafb;
+        transition: border 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      .field input[type="range"] {
+        padding: 0;
+      }
+
+      .field select:focus,
+      .field input[type="number"]:focus,
+      .field input[type="text"]:focus,
+      .field input[type="url"]:focus,
+      .field input[type="range"]:focus {
+        outline: none;
+        border-color: #4f46e5;
+        box-shadow: 0 0 0 3px rgba(79, 70, 229, 0.2);
+      }
+
+      .inline-group {
+        display: flex;
+        gap: 16px;
+        flex-wrap: wrap;
+      }
+
+      .inline-group .field {
+        flex: 1 1 160px;
+      }
+
+      .slider-value {
+        font-size: 1.1rem;
+        font-weight: 600;
+        margin-top: 6px;
+        color: #1f2937;
+      }
+
+      .note {
+        font-size: 0.875rem;
+        color: #6b7280;
+      }
+
+      .health-options {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+        gap: 12px;
+      }
+
+      .checkbox-pill {
+        border: 1px solid #d1d5db;
+        background: #f9fafb;
+        border-radius: 999px;
+        padding: 8px 14px;
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        cursor: pointer;
+        transition: background 0.2s ease, border 0.2s ease, color 0.2s ease;
+      }
+
+      .checkbox-pill input {
+        accent-color: #4f46e5;
+      }
+
+      .checkbox-pill input:checked + span,
+      .checkbox-pill input:focus + span {
+        font-weight: 600;
+      }
+
+      .checkbox-pill:hover {
+        border-color: #4f46e5;
+        background: rgba(79, 70, 229, 0.06);
+      }
+
+      .actions {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 16px;
+        align-items: center;
+        justify-content: flex-start;
+      }
+
+      button[type="submit"] {
+        background: #4f46e5;
+        color: #ffffff;
+        font-weight: 600;
+        border: none;
+        border-radius: 999px;
+        padding: 14px 28px;
+        cursor: pointer;
+        transition: transform 0.15s ease, box-shadow 0.15s ease;
+        box-shadow: 0 12px 25px -12px rgba(79, 70, 229, 0.7);
+      }
+
+      button[type="submit"]:hover {
+        transform: translateY(-1px);
+        box-shadow: 0 14px 30px -12px rgba(79, 70, 229, 0.8);
+      }
+
+      button[type="submit"]:active {
+        transform: translateY(0);
+      }
+
+      .results-card {
+        padding: 28px 32px;
+      }
+
+      .results-header {
+        display: flex;
+        flex-direction: column;
+        gap: 4px;
+        margin-bottom: 20px;
+      }
+
+      .results-header span {
+        color: #6b7280;
+        font-size: 0.9rem;
+      }
+
+      .quote-tool__list {
+        display: grid;
+        gap: 14px;
+      }
+
+      .quote-tool__item {
+        background: #f9fafb;
+        border-radius: 14px;
+        padding: 18px 20px;
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        border: 1px solid #e5e7eb;
+      }
+
+      .quote-tool__label {
+        font-weight: 600;
+        color: #1f2937;
+      }
+
+      .quote-tool__cta {
+        background: #111827;
+        color: #ffffff;
+        padding: 10px 20px;
+        border-radius: 999px;
+        text-decoration: none;
+        font-weight: 600;
+        transition: background 0.2s ease, transform 0.2s ease;
+      }
+
+      .quote-tool__cta:hover {
+        background: #000000;
+        transform: translateY(-1px);
+      }
+
+      .quote-tool__cta:focus {
+        outline: 3px solid rgba(17, 24, 39, 0.3);
+        outline-offset: 2px;
+      }
+
+      .error-message {
+        background: rgba(220, 38, 38, 0.1);
+        color: #b91c1c;
+        border-radius: 12px;
+        padding: 12px 16px;
+        display: none;
+      }
+
+      .error-message.is-visible {
+        display: block;
+      }
+
+      .status {
+        font-size: 0.95rem;
+        color: #6b7280;
+      }
+
+      .status strong {
+        color: #111827;
+      }
+
+      @media (max-width: 600px) {
+        .card {
+          padding: 28px 22px;
+        }
+
+        .inline-group {
+          flex-direction: column;
+        }
+
+        .quote-tool__item {
+          flex-direction: column;
+          align-items: flex-start;
+        }
+
+        .quote-tool__cta {
+          align-self: stretch;
+          text-align: center;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <div class="page">
+      <div class="card">
+        <h1>Life Insurance Quote Tool</h1>
+        <p class="lead">Single-screen. Minimal questions. Auto-uses whatever carriers/products are present in the embedded JSON.</p>
+        <form id="quote-form">
+          <div class="inline-group">
+            <div class="field">
+              <label for="state">State</label>
+              <select id="state" name="state" required></select>
+            </div>
+            <div class="field">
+              <label for="age">Age</label>
+              <input id="age" name="age" type="number" min="18" max="80" value="50" required />
+            </div>
+            <div class="field">
+              <label for="gender">Gender</label>
+              <select id="gender" name="gender" required>
+                <option value="male">Male</option>
+                <option value="female">Female</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="field">
+            <label for="coverage">Coverage Amount</label>
+            <input id="coverage" name="coverage" type="range" min="10000" max="1000000" step="5000" value="100000" />
+            <div class="slider-value" id="coverage-display">$100,000</div>
+            <p class="note">Final expense typical range shown. Tool enforces product min/max per carrier at calculation time.</p>
+          </div>
+
+          <div class="inline-group" id="product-row">
+            <div class="field">
+              <label for="product-type">Product</label>
+              <select id="product-type" name="product" required></select>
+            </div>
+            <div class="field" id="term-field" hidden>
+              <label for="term">Term Length (years)</label>
+              <select id="term" name="term"></select>
+            </div>
+            <div class="field">
+              <label for="modality">Payment Mode</label>
+              <select id="modality" name="modality">
+                <option value="monthly">Monthly</option>
+                <option value="quarterly">Quarterly</option>
+                <option value="semi_annual">Semi-Annual</option>
+                <option value="annual">Annual</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="inline-group">
+            <div class="field">
+              <label for="nicotine">Tobacco/Nicotine in last 12 months?</label>
+              <select id="nicotine" name="nicotine">
+                <option value="false">No</option>
+                <option value="true">Yes</option>
+              </select>
+            </div>
+            <div class="field">
+              <label>Calculated Health Class</label>
+              <div class="status">Current: <strong id="health-class">Preferred Plus</strong></div>
+            </div>
+          </div>
+
+          <div class="field">
+            <label>Health (check any that apply)</label>
+            <div class="health-options">
+              <label class="checkbox-pill">
+                <input type="checkbox" name="health" value="copd" />
+                <span>COPD/Emphysema</span>
+              </label>
+              <label class="checkbox-pill">
+                <input type="checkbox" name="health" value="oxygen" />
+                <span>On Oxygen</span>
+              </label>
+              <label class="checkbox-pill">
+                <input type="checkbox" name="health" value="diabetes" />
+                <span>Diabetes</span>
+              </label>
+              <label class="checkbox-pill">
+                <input type="checkbox" name="health" value="insulin" />
+                <span>On Insulin</span>
+              </label>
+              <label class="checkbox-pill">
+                <input type="checkbox" name="health" value="heart" />
+                <span>Heart Attack/Stroke</span>
+              </label>
+              <label class="checkbox-pill">
+                <input type="checkbox" name="health" value="dementia" />
+                <span>Dementia/Alzheimer's</span>
+              </label>
+            </div>
+          </div>
+
+          <div class="inline-group">
+            <div class="field">
+              <label for="button-text">Button Text</label>
+              <input id="button-text" name="buttonText" type="text" value="Book now" required />
+            </div>
+            <div class="field">
+              <label for="link-url">Button Link URL</label>
+              <input id="link-url" name="linkUrl" type="url" value="https://example.com/book" required />
+            </div>
+          </div>
+
+          <div class="actions">
+            <button type="submit">Get Quotes</button>
+            <div class="status" id="status-text">Rates are estimates based on uploaded carrier tables & factors.</div>
+          </div>
+          <div class="error-message" id="error-message"></div>
+        </form>
+      </div>
+
+      <div class="card results-card">
+        <div class="results-header">
+          <h2>Available quotes</h2>
+          <span id="quote-count">No quotes yet</span>
+        </div>
+        <div id="quotes"></div>
+      </div>
+    </div>
+
+    <script src="quote_tool.js"></script>
+    <script>
+      (function () {
+        const STATES = [
+          "AL","AK","AZ","AR","CA","CO","CT","DE","DC","FL","GA","HI","ID","IL","IN","IA","KS","KY","LA","ME","MD","MA","MI","MN","MS","MO","MT","NE","NV","NH","NJ","NM","NY","NC","ND","OH","OK","OR","PA","RI","SC","SD","TN","TX","UT","VT","VA","WA","WV","WI","WY"
+        ];
+
+        const HEALTH_SCORES = {
+          nicotine: 2,
+          copd: 4,
+          oxygen: 5,
+          diabetes: 2,
+          insulin: 3,
+          heart: 3,
+          dementia: 4
+        };
+
+        const stateSelect = document.getElementById("state");
+        const productSelect = document.getElementById("product-type");
+        const termField = document.getElementById("term-field");
+        const termSelect = document.getElementById("term");
+        const coverageSlider = document.getElementById("coverage");
+        const coverageDisplay = document.getElementById("coverage-display");
+        const nicotineSelect = document.getElementById("nicotine");
+        const healthClassText = document.getElementById("health-class");
+        const form = document.getElementById("quote-form");
+        const quotesContainer = document.getElementById("quotes");
+        const statusText = document.getElementById("status-text");
+        const errorMessage = document.getElementById("error-message");
+        const quoteCount = document.getElementById("quote-count");
+
+        let calculator = null;
+        let underwritingData = null;
+        let productsByType = new Map();
+
+        function formatCurrency(value) {
+          return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(value);
+        }
+
+        function updateCoverageDisplay() {
+          coverageDisplay.textContent = formatCurrency(Number(coverageSlider.value));
+        }
+
+        function determineHealthClass() {
+          const nicotineUse = nicotineSelect.value === "true";
+          const selected = Array.from(form.querySelectorAll('input[name="health"]:checked')).map((input) => input.value);
+          let score = nicotineUse ? HEALTH_SCORES.nicotine : 0;
+          for (const item of selected) {
+            score += HEALTH_SCORES[item] || 1;
+          }
+
+          let healthClass = "preferred_plus";
+          if (score <= 1) {
+            healthClass = "preferred_plus";
+          } else if (score <= 3) {
+            healthClass = "preferred";
+          } else if (score <= 5) {
+            healthClass = "standard_plus";
+          } else if (score <= 7) {
+            healthClass = "standard";
+          } else if (score <= 9) {
+            healthClass = "table_a";
+          } else {
+            healthClass = "table_b";
+          }
+
+          const friendly = healthClass
+            .replace(/_/g, " ")
+            .replace(/\b\w/g, (c) => c.toUpperCase());
+          healthClassText.textContent = friendly;
+          return healthClass;
+        }
+
+        function populateStates() {
+          const fragment = document.createDocumentFragment();
+          STATES.forEach((abbr) => {
+            const option = document.createElement("option");
+            option.value = abbr;
+            option.textContent = abbr;
+            fragment.appendChild(option);
+          });
+          stateSelect.appendChild(fragment);
+          stateSelect.value = "TX";
+        }
+
+        function populateProducts() {
+          productsByType = new Map();
+          const optionFragment = document.createDocumentFragment();
+
+          underwritingData.carriers.forEach((carrier) => {
+            carrier.products.forEach((product) => {
+              const type = product.type || "other";
+              if (!productsByType.has(type)) {
+                productsByType.set(type, new Set());
+              }
+              if (product.term_years) {
+                productsByType.get(type).add(product.term_years);
+              }
+            });
+          });
+
+          const typeLabels = {
+            term: "Term Life",
+            whole: "Whole Life",
+            ul: "Universal Life"
+          };
+
+          for (const [type] of productsByType) {
+            const option = document.createElement("option");
+            option.value = type;
+            option.textContent = typeLabels[type] || type.replace(/_/g, " " ).replace(/\b\w/g, (c) => c.toUpperCase());
+            optionFragment.appendChild(option);
+          }
+
+          productSelect.appendChild(optionFragment);
+          if (productSelect.options.length > 0) {
+            productSelect.value = productSelect.options[0].value;
+          }
+          refreshTermOptions();
+        }
+
+        function refreshTermOptions() {
+          const type = productSelect.value;
+          const terms = Array.from(productsByType.get(type) || []);
+          termSelect.innerHTML = "";
+          if (terms.length === 0) {
+            termField.hidden = true;
+            return;
+          }
+
+          termField.hidden = false;
+          const fragment = document.createDocumentFragment();
+          terms.sort((a, b) => a - b);
+          terms.forEach((term) => {
+            const option = document.createElement("option");
+            option.value = term;
+            option.textContent = `${term} years`;
+            fragment.appendChild(option);
+          });
+          termSelect.appendChild(fragment);
+        }
+
+        function showError(message) {
+          errorMessage.textContent = message;
+          errorMessage.classList.add("is-visible");
+        }
+
+        function clearError() {
+          errorMessage.textContent = "";
+          errorMessage.classList.remove("is-visible");
+        }
+
+        async function initialise() {
+          if (!window.QuoteTool) {
+            showError("QuoteTool is not available. Ensure quote_tool.js is loaded.");
+            return;
+          }
+
+          statusText.textContent = "Loading underwriting data...";
+
+          try {
+            underwritingData = await window.QuoteTool.loadUnderwritingData("carrier_underwriting.json");
+            calculator = new window.QuoteTool.QuoteCalculator(underwritingData);
+            statusText.textContent = "Ready. Adjust the inputs and click Get Quotes.";
+            populateProducts();
+          } catch (error) {
+            console.error(error);
+            showError("Unable to load underwriting data. Serve the folder via a local web server (see README).");
+            statusText.textContent = "";
+          }
+        }
+
+        function renderQuotes(quotes) {
+          quotesContainer.innerHTML = "";
+          if (!quotes || quotes.length === 0) {
+            quoteCount.textContent = "No quotes available for the selected profile.";
+            return;
+          }
+
+          quoteCount.textContent = `${quotes.length} quote${quotes.length === 1 ? "" : "s"} found`;
+          window.QuoteTool.renderQuoteList(quotes, { container: quotesContainer });
+        }
+
+        populateStates();
+        updateCoverageDisplay();
+        determineHealthClass();
+        initialise();
+
+        coverageSlider.addEventListener("input", updateCoverageDisplay);
+        nicotineSelect.addEventListener("change", determineHealthClass);
+        form.querySelectorAll('input[name="health"]').forEach((input) => {
+          input.addEventListener("change", determineHealthClass);
+        });
+        productSelect.addEventListener("change", () => {
+          refreshTermOptions();
+        });
+
+        form.addEventListener("submit", (event) => {
+          event.preventDefault();
+          clearError();
+
+          if (!calculator) {
+            showError("Calculator is not ready yet. Please wait for underwriting data to load.");
+            return;
+          }
+
+          const healthClass = determineHealthClass();
+
+          const request = {
+            age: Number(document.getElementById("age").value),
+            gender: document.getElementById("gender").value,
+            state: stateSelect.value,
+            coverageAmount: Number(coverageSlider.value),
+            productType: productSelect.value,
+            healthClass,
+            nicotineUse: nicotineSelect.value === "true",
+            modality: document.getElementById("modality").value,
+            buttonText: document.getElementById("button-text").value.trim(),
+            linkUrl: document.getElementById("link-url").value.trim()
+          };
+
+          if (request.productType === "term" && !termField.hidden) {
+            request.termYears = Number(termSelect.value);
+          }
+
+          try {
+            const quotes = calculator.calculateQuotes(request);
+            renderQuotes(quotes);
+          } catch (error) {
+            console.error(error);
+            showError(error.message);
+          }
+        });
+      })();
+    </script>
+  </body>
+</html>

--- a/quote_tool.js
+++ b/quote_tool.js
@@ -1,0 +1,374 @@
+(function (globalScope, factory) {
+  if (typeof module === "object" && typeof module.exports === "object") {
+    module.exports = factory();
+  } else {
+    const existing = globalScope.QuoteTool;
+    const api = factory();
+    api.noConflict = function noConflict() {
+      globalScope.QuoteTool = existing;
+      return api;
+    };
+    globalScope.QuoteTool = api;
+  }
+})(typeof window !== "undefined" ? window : globalThis, function quoteToolFactory() {
+  "use strict";
+
+  const DEFAULT_MODALITY = "monthly";
+  const SUPPORTED_GENDERS = new Set(["male", "female"]);
+
+  const DEFAULTS = Object.freeze({
+    currency: "USD",
+    currencySymbol: "$",
+    baseCoverageUnit: 1000,
+    modalFactors: {
+      annual: 1,
+      semi_annual: 0.52,
+      quarterly: 0.265,
+      monthly: 0.09
+    },
+    buttonText: "Book now",
+    linkUrl: "#"
+  });
+
+  const HEALTH_CLASS_ALIASES = Object.freeze({
+    "preferred plus": "preferred_plus",
+    "preferred+": "preferred_plus",
+    "preferred plus non-tobacco": "preferred_plus",
+    "preferred": "preferred",
+    "standard plus": "standard_plus",
+    "standard+": "standard_plus",
+    "standard": "standard",
+    "table a": "table_a",
+    "table b": "table_b"
+  });
+
+  function clone(value) {
+    if (!value || typeof value !== "object") return value;
+    if (Array.isArray(value)) return value.map(clone);
+    return Object.keys(value).reduce((acc, key) => {
+      acc[key] = clone(value[key]);
+      return acc;
+    }, {});
+  }
+
+  function normaliseKey(value) {
+    return String(value || "")
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, " ");
+  }
+
+  function normaliseHealthClass(value) {
+    const key = normaliseKey(value).replace(/[^a-z+ ]/g, "");
+    return HEALTH_CLASS_ALIASES[key] || key.replace(/\s+/g, "_");
+  }
+
+  function assertNumber(name, value) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+      throw new TypeError(`${name} must be a finite number.`);
+    }
+    return numeric;
+  }
+
+  function formatCurrency(amount, currencySymbol) {
+    const value = Number(amount);
+    if (!Number.isFinite(value)) return "-";
+    return `${currencySymbol}${value.toFixed(2)}`;
+  }
+
+  function resolveModalFactor(product, modality) {
+    const modal = modality || DEFAULT_MODALITY;
+    const factors = {
+      ...DEFAULTS.modalFactors,
+      ...(product && product.modal_factors ? product.modal_factors : {})
+    };
+    if (!Object.prototype.hasOwnProperty.call(factors, modal)) {
+      throw new RangeError(`Unsupported payment modality \"${modal}\".`);
+    }
+    return { modal, factor: factors[modal] };
+  }
+
+  function stateAdjustment(product, state) {
+    if (!product) return 1;
+    if (product.state_exclusions && product.state_exclusions.includes(state)) {
+      return 0;
+    }
+    const adjustments = product.state_factors || {};
+    return Object.prototype.hasOwnProperty.call(adjustments, state)
+      ? adjustments[state]
+      : 1;
+  }
+
+  function findRateBand(rateTable, age) {
+    if (!Array.isArray(rateTable)) {
+      throw new TypeError("Product rate_table must be an array of age bands.");
+    }
+    return rateTable.find((band) => {
+      const min = Number.isFinite(band.min_age) ? band.min_age : 0;
+      const max = Number.isFinite(band.max_age) ? band.max_age : Infinity;
+      return age >= min && age <= max;
+    });
+  }
+
+  function guardGenderRate(rateBand, gender) {
+    const normalisedGender = normaliseKey(gender);
+    if (!SUPPORTED_GENDERS.has(normalisedGender)) {
+      throw new RangeError(`Unsupported gender \"${gender}\". Expected: ${Array.from(SUPPORTED_GENDERS).join(", ")}`);
+    }
+    const rates = rateBand.rates || {};
+    if (!Object.prototype.hasOwnProperty.call(rates, normalisedGender)) {
+      throw new RangeError(`No rate available for gender \"${gender}\" within the selected band.`);
+    }
+    return rates[normalisedGender];
+  }
+
+  function resolveFactor(map, key, defaultValue = 1) {
+    if (!map) return defaultValue;
+    const normalised = normaliseHealthClass(key);
+    if (Object.prototype.hasOwnProperty.call(map, normalised)) {
+      return map[normalised];
+    }
+    return Object.prototype.hasOwnProperty.call(map, key)
+      ? map[key]
+      : defaultValue;
+  }
+
+  function buildBreakdown(details) {
+    return {
+      baseRatePerUnit: details.baseRatePerUnit,
+      baseCoverageUnit: details.baseCoverageUnit,
+      coverageAmount: details.coverageAmount,
+      age: details.age,
+      gender: details.gender,
+      rateBand: clone(details.rateBand),
+      healthClass: details.healthClass,
+      nicotineUse: details.nicotineUse,
+      appliedFactors: clone(details.appliedFactors),
+      policyFeeAnnual: details.policyFeeAnnual,
+      modality: details.modality,
+      modalFactor: details.modalFactor,
+      annualPremiumBeforeFees: details.annualPremiumBeforeFees,
+      annualPremiumAfterFees: details.annualPremiumAfterFees,
+      modalPremium: details.modalPremium
+    };
+  }
+
+  class QuoteCalculator {
+    constructor(underwritingData) {
+      if (!underwritingData || typeof underwritingData !== "object") {
+        throw new TypeError("underwritingData must be an object.");
+      }
+      const metadata = underwritingData.metadata || {};
+      this.metadata = {
+        currency: metadata.currency || DEFAULTS.currency,
+        currencySymbol: metadata.currency_symbol || DEFAULTS.currencySymbol,
+        baseCoverageUnit: metadata.base_coverage_unit || DEFAULTS.baseCoverageUnit
+      };
+      this.carriers = Array.isArray(underwritingData.carriers)
+        ? underwritingData.carriers.slice()
+        : [];
+    }
+
+    listCarriers() {
+      return this.carriers.map((carrier) => carrier.name);
+    }
+
+    calculateQuotes(request) {
+      if (!request) {
+        throw new TypeError("A request object is required to calculate quotes.");
+      }
+      const age = assertNumber("age", request.age);
+      const coverageAmount = assertNumber("coverageAmount", request.coverageAmount);
+      const gender = normaliseKey(request.gender);
+      const state = (request.state || "").toUpperCase();
+      const healthClass = normaliseHealthClass(request.healthClass || "standard");
+      const nicotineUse = Boolean(request.nicotineUse);
+      const modality = request.modality || DEFAULT_MODALITY;
+      const productFilter = request.productType ? normaliseKey(request.productType) : null;
+      const termFilter = Number.isFinite(request.termYears) ? Number(request.termYears) : null;
+      const linkUrl = request.linkUrl || DEFAULTS.linkUrl;
+      const buttonText = request.buttonText || DEFAULTS.buttonText;
+
+      if (coverageAmount <= 0) {
+        throw new RangeError("coverageAmount must be greater than zero.");
+      }
+
+      const quotes = [];
+
+      for (const carrier of this.carriers) {
+        if (!carrier || typeof carrier !== "object") continue;
+        const carrierName = carrier.name || "Unnamed Carrier";
+        const products = Array.isArray(carrier.products) ? carrier.products : [];
+
+        for (const product of products) {
+          const productType = normaliseKey(product.type || product.product_type || product.name || "");
+          const termYears = Number.isFinite(product.term_years) ? product.term_years : null;
+
+          if (productFilter && productType !== productFilter) continue;
+          if (termFilter !== null && termYears !== termFilter) continue;
+
+          const stateFactor = stateAdjustment(product, state);
+          if (stateFactor === 0) continue;
+
+          const rateBand = findRateBand(product.rate_table || [], age);
+          if (!rateBand) continue;
+          const baseRatePerUnit = guardGenderRate(rateBand, gender);
+
+          const baseCoverageUnit = product.base_coverage_unit || this.metadata.baseCoverageUnit;
+          const coverageUnits = coverageAmount / baseCoverageUnit;
+          if (!Number.isFinite(coverageUnits) || coverageUnits <= 0) continue;
+
+          const healthFactor = resolveFactor(product.health_factors, healthClass, 1);
+          const nicotineFactor = resolveFactor(product.nicotine_factors, nicotineUse ? "true" : "false", nicotineUse ? 1.5 : 1);
+          const productFactor = Number.isFinite(product.product_factor) ? product.product_factor : 1;
+          const annualPremiumBeforeFees = baseRatePerUnit * coverageUnits * healthFactor * nicotineFactor * stateFactor * productFactor;
+
+          const policyFeeAnnual = Number.isFinite(product.policy_fee_annual) ? product.policy_fee_annual : 0;
+
+          const { modal, factor: modalFactor } = resolveModalFactor(product, modality);
+
+          const annualPremiumAfterFees = annualPremiumBeforeFees + policyFeeAnnual;
+          const modalPremium = annualPremiumAfterFees * modalFactor;
+
+          const formattedPremium = Number(modalPremium.toFixed(2));
+
+          quotes.push({
+            carrier: carrierName,
+            product: product.name || carrierName,
+            productType,
+            termYears,
+            coverageAmount,
+            premium: formattedPremium,
+            currency: this.metadata.currency,
+            currencySymbol: this.metadata.currencySymbol,
+            modality: modal,
+            linkUrl,
+            buttonText,
+            breakdown: buildBreakdown({
+              baseRatePerUnit,
+              baseCoverageUnit,
+              coverageAmount,
+              age,
+              gender,
+              rateBand,
+              healthClass,
+              nicotineUse,
+              appliedFactors: {
+                health: healthFactor,
+                nicotine: nicotineFactor,
+                state: stateFactor,
+                product: productFactor
+              },
+              policyFeeAnnual,
+              modality: modal,
+              modalFactor,
+              annualPremiumBeforeFees,
+              annualPremiumAfterFees,
+              modalPremium
+            })
+          });
+        }
+      }
+
+      quotes.sort((a, b) => a.premium - b.premium);
+      return quotes;
+    }
+  }
+
+  async function loadUnderwritingData(source) {
+    if (!source) {
+      throw new TypeError("A source is required to load underwriting data.");
+    }
+
+    if (typeof source === "object") {
+      return source;
+    }
+
+    if (typeof source !== "string") {
+      throw new TypeError("source must be either an object or a string path/URL.");
+    }
+
+    if (typeof window !== "undefined" && typeof window.fetch === "function") {
+      const response = await window.fetch(source, { headers: { Accept: "application/json" } });
+      if (!response.ok) {
+        throw new Error(`Unable to load underwriting data: ${response.status} ${response.statusText}`);
+      }
+      return response.json();
+    }
+
+    if (typeof require === "function") {
+      try {
+        const fs = require("fs/promises");
+        const data = await fs.readFile(source, "utf8");
+        return JSON.parse(data);
+      } catch (error) {
+        if (error && error.code === "MODULE_NOT_FOUND") {
+          throw new Error("fs/promises module is not available in this environment.");
+        }
+        throw error;
+      }
+    }
+
+    throw new Error("Unable to load underwriting data in the current environment.");
+  }
+
+  function renderQuoteList(quotes, options) {
+    if (!Array.isArray(quotes)) {
+      throw new TypeError("quotes must be an array returned by calculateQuotes.");
+    }
+    const settings = {
+      container: null,
+      currencySymbol: quotes[0] ? quotes[0].currencySymbol : DEFAULTS.currencySymbol,
+      onButtonClick: null,
+      ...options
+    };
+
+    if (!settings.container) {
+      throw new Error("A container element is required to render quotes.");
+    }
+
+    const container = settings.container;
+    container.innerHTML = "";
+
+    const list = container.ownerDocument.createElement("div");
+    list.className = "quote-tool__list";
+
+    for (const quote of quotes) {
+      const item = container.ownerDocument.createElement("div");
+      item.className = "quote-tool__item";
+
+      const label = container.ownerDocument.createElement("div");
+      label.className = "quote-tool__label";
+      label.textContent = `${quote.carrier} - ${formatCurrency(quote.premium, settings.currencySymbol)}/${quote.modality}`;
+      item.appendChild(label);
+
+      const button = container.ownerDocument.createElement("a");
+      button.className = "quote-tool__cta";
+      button.href = quote.linkUrl || "#";
+      button.textContent = quote.buttonText || DEFAULTS.buttonText;
+      button.setAttribute("data-carrier", quote.carrier);
+      button.setAttribute("data-product", quote.product);
+      button.setAttribute("role", "button");
+
+      if (typeof settings.onButtonClick === "function") {
+        button.addEventListener("click", (event) => {
+          settings.onButtonClick(event, quote);
+        });
+      }
+
+      item.appendChild(button);
+      list.appendChild(item);
+    }
+
+    container.appendChild(list);
+    return container;
+  }
+
+  return {
+    QuoteCalculator,
+    loadUnderwritingData,
+    renderQuoteList,
+    formatCurrency
+  };
+});

--- a/scripts/run_quote.js
+++ b/scripts/run_quote.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+const path = require('path');
+const fs = require('fs');
+const { QuoteCalculator, loadUnderwritingData } = require('../quote_tool.js');
+
+function printUsage() {
+  console.log(`Usage: node scripts/run_quote.js [options]\n\n` +
+    `Options (defaults in parentheses):\n` +
+    `  --data <path>             Path to underwriting JSON (./carrier_underwriting.json)\n` +
+    `  --age <number>            Client age (35)\n` +
+    `  --gender <male|female>    Client gender (male)\n` +
+    `  --state <code>            Two-letter state code (TX)\n` +
+    `  --coverage <number>       Coverage amount in dollars (250000)\n` +
+    `  --term <number>           Term length in years (20)\n` +
+    `  --product <type>          Product type: term | whole | iul (term)\n` +
+    `  --health <class>          Health class (preferred plus)\n` +
+    `  --nicotine <true|false>   Nicotine use flag (false)\n` +
+    `  --modality <mode>         Payment mode: monthly | annual | quarterly | semiannual (monthly)\n` +
+    `  --button <text>           CTA button label (Book now)\n` +
+    `  --link <url>              CTA destination URL (https://example.com/book)\n` +
+    `  --help                    Show this message\n`);
+}
+
+function parseArgs(argv) {
+  const opts = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) {
+      continue;
+    }
+    const key = arg.slice(2);
+    if (key === 'help') {
+      opts.help = true;
+      continue;
+    }
+    const value = argv[i + 1];
+    if (typeof value === 'undefined' || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`);
+    }
+    opts[key] = value;
+    i += 1;
+  }
+  return opts;
+}
+
+function coerceBoolean(value, fallback) {
+  if (typeof value === 'undefined') {
+    return fallback;
+  }
+  if (value === 'true') return true;
+  if (value === 'false') return false;
+  throw new Error(`Invalid boolean value: ${value}`);
+}
+
+(async function main() {
+  try {
+    const args = parseArgs(process.argv.slice(2));
+    if (args.help) {
+      printUsage();
+      return;
+    }
+
+    const dataPath = path.resolve(process.cwd(), args.data || './carrier_underwriting.json');
+    if (!fs.existsSync(dataPath)) {
+      throw new Error(`Cannot find underwriting file at ${dataPath}`);
+    }
+
+    const underwritingData = await loadUnderwritingData(dataPath);
+    const calculator = new QuoteCalculator(underwritingData);
+
+    const quoteRequest = {
+      age: Number.parseInt(args.age || '35', 10),
+      gender: (args.gender || 'male').toLowerCase(),
+      state: (args.state || 'TX').toUpperCase(),
+      coverageAmount: Number.parseInt(args.coverage || '250000', 10),
+      termYears: Number.parseInt(args.term || '20', 10),
+      productType: (args.product || 'term').toLowerCase(),
+      healthClass: (args.health || 'preferred plus').toLowerCase(),
+      nicotineUse: coerceBoolean(args.nicotine, false),
+      modality: (args.modality || 'monthly').toLowerCase(),
+      buttonText: args.button || 'Book now',
+      linkUrl: args.link || 'https://example.com/book'
+    };
+
+    const quotes = calculator.calculateQuotes(quoteRequest);
+    if (!quotes.length) {
+      console.log('No quotes available for the supplied criteria.');
+      return;
+    }
+
+    console.log('Quotes:\n');
+    for (const quote of quotes) {
+      console.log(`${quote.carrier} (${quote.product}) - ${quote.premium}/${quote.modality} - ${quote.buttonText}`);
+      console.log(`  Link: ${quote.linkUrl}`);
+    }
+  } catch (error) {
+    console.error(error.message);
+    printUsage();
+    process.exitCode = 1;
+  }
+})();


### PR DESCRIPTION
## Summary
- add a lightweight CLI script for generating quotes from the underwriting data
- document the helper in the README so the widget can be exercised quickly

## Testing
- node scripts/run_quote.js --age 35 --gender male --state TX --coverage 250000 --term 20 --product term --health "preferred plus" --nicotine false --modality monthly --button "Book now" --link "https://example.com/book"

------
https://chatgpt.com/codex/tasks/task_e_68dd5a9efbf883269ec9b7b3abbb1178